### PR TITLE
Activate `systemvars` to load all system and react .env variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,8 @@ function compile(entry) {
       new Dotenv({
         path: program.env, // Path to .env file (this is the default)
         safe: false, // load .env.example (defaults to "false" which does not use dotenv-safe)
-        silent: true
+        silent: true,
+        systemvars: true // Load all system variables and REACT .env as well
       })
       // new webpack.optimize.UglifyJsPlugin()
     ]


### PR DESCRIPTION
This tweak made exploitation of variable such as `process.env.npm_package_version` and any env variable in CRA's .env files possible.